### PR TITLE
Execute googleclient commands in datastore existence check

### DIFF
--- a/fitsync.py
+++ b/fitsync.py
@@ -96,14 +96,14 @@ def main():
   try:
     googleClient.users().dataSources().get(
       userId='me',
-      dataSourceId=dataSourceId)
+      dataSourceId=dataSourceId).execute()
   except HttpError, error:
     if not 'DataSourceId not found' in str(error):
       raise error
     # Doesn't exist, so create it.
     googleClient.users().dataSources().create(
       userId='me',
-      body=dataSource)
+      body=dataSource).execute()
 
   datasetId = '%s-%s' % (minLogNs, maxLogNs)
 


### PR DESCRIPTION
Noticed the commands in the datastore existence check were never executed which causes the sync to fail the first time you run it. 
